### PR TITLE
Updates for Darwin, Linux

### DIFF
--- a/spec/uname_spec.cr
+++ b/spec/uname_spec.cr
@@ -26,6 +26,15 @@ describe System do
     System.version.should eq(expected)
   end
 
+  it "correctly reports the model on Darwin or raises an error if not supported" do
+    {% if flag?(:darwin) %}
+      expected = `sysctl hw.model`.split(":").last.strip
+      System.model.should eq(expected)
+    {% else %}
+      expect_raises(RuntimeError, "the model method is unsupported on this platform")
+    {% end %}
+  end
+
   it "returns a struct if the uname method is used" do
     System.uname.should be_a(System::Uname)
   end

--- a/spec/uname_spec.cr
+++ b/spec/uname_spec.cr
@@ -31,7 +31,7 @@ describe System do
       expected = `sysctl hw.model`.split(":").last.strip
       System.model.should eq(expected)
     {% else %}
-      expect_raises(RuntimeError, "the model method is unsupported on this platform"){}
+      expect_raises(Exception, "the model method is unsupported on this platform"){ System.model }
     {% end %}
   end
 

--- a/spec/uname_spec.cr
+++ b/spec/uname_spec.cr
@@ -31,7 +31,7 @@ describe System do
       expected = `sysctl hw.model`.split(":").last.strip
       System.model.should eq(expected)
     {% else %}
-      expect_raises(RuntimeError, "the model method is unsupported on this platform")
+      expect_raises(RuntimeError, "the model method is unsupported on this platform"){}
     {% end %}
   end
 

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -3,13 +3,27 @@ module System
     CTL_HW = 6
     HW_MODEL = 2
 
-    struct Uname
-      sysname : ::LibC::Char[256]
-      nodename : ::LibC::Char[256]
-      release : ::LibC::Char[256]
-      version : ::LibC::Char[256]
-      machine : ::LibC::Char[256]
-    end
+    {% if flag?(:linux) %}
+      BUF_SIZE = 65
+      struct Uname
+        sysname : ::LibC::Char[BUF_SIZE]
+        nodename : ::LibC::Char[BUF_SIZE]
+        release : ::LibC::Char[BUF_SIZE]
+        version : ::LibC::Char[BUF_SIZE]
+        machine : ::LibC::Char[BUF_SIZE]
+        domainname : ::LibC::Char[BUF_SIZE]
+      end
+    {% else %}
+      BUF_SIZE = 256
+      struct Uname
+        sysname : ::LibC::Char[BUF_SIZE]
+        nodename : ::LibC::Char[BUF_SIZE]
+        release : ::LibC::Char[BUF_SIZE]
+        version : ::LibC::Char[BUF_SIZE]
+        machine : ::LibC::Char[BUF_SIZE]
+      end
+    {% end %}
+
 
     # The core language has a c/sysctl lib, but not for Macs yet.
 

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -83,7 +83,9 @@ module System
     uname.machine
   end
 
-  def self.model
+  # Returns the hardware model name.
+  #
+  def self.model : String
     mib = Int32[LibC::CTL_HW, LibC::HW_MODEL]
     buf = GC.malloc_atomic(256).as(UInt8*)
     size = ::LibC::SizeT.new(256)

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -86,14 +86,18 @@ module System
   # Returns the hardware model name.
   #
   def self.model : String
-    mib = Int32[LibC::CTL_HW, LibC::HW_MODEL]
-    buf = Bytes.new(256)
-    size = ::LibC::SizeT.new(256)
+    {% if flag?(:darwin) %}
+      mib = Int32[LibC::CTL_HW, LibC::HW_MODEL]
+      buf = Bytes.new(256)
+      size = ::LibC::SizeT.new(256)
 
-    if LibC.sysctl(mib, 2, buf, pointerof(size), nil, 0) < 0
-      raise "sysctl function failed"
-    end
+      LibC.sysctl(mib, 2, buf, pointerof(size), nil, 0) < 0
+        raise RuntimeError.from_errno("sysctl")
+      end
 
-    String.new(buf)[0, size - 1]
+      String.new(buf)[0, size - 1]
+    {% else %}
+      raise "the model method is unsupported on this platform"
+    {% end %}
   end
 end

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -88,7 +88,7 @@ module System
   def self.model : String
     {% if flag?(:darwin) %}
       mib = Int32[LibC::CTL_HW, LibC::HW_MODEL]
-      buf = Bytes.new(256)
+      buf = Bytes.new(64)
       size = ::LibC::SizeT.new(buf.size)
 
       if LibC.sysctl(mib, 2, buf, pointerof(size), nil, 0) < 0

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -14,7 +14,10 @@ module System
     # The core language has a c/sysctl lib, but not for Macs yet.
 
     fun uname(value : Uname*) : Int32
-    fun sysctl(name : Int32*, namelen : UInt32, oldp : Void*, oldlenp : ::LibC::SizeT*, newp : Void*, newlen : ::LibC::SizeT) : Int32
+
+    {% unless flag?(:linux) %}
+      fun sysctl(name : Int32*, namelen : UInt32, oldp : Void*, oldlenp : ::LibC::SizeT*, newp : Void*, newlen : ::LibC::SizeT) : Int32
+    {% end %}
   end
 
   struct Uname

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -91,7 +91,7 @@ module System
       buf = Bytes.new(256)
       size = ::LibC::SizeT.new(256)
 
-      LibC.sysctl(mib, 2, buf, pointerof(size), nil, 0) < 0
+      if LibC.sysctl(mib, 2, buf, pointerof(size), nil, 0) < 0
         raise RuntimeError.from_errno("sysctl")
       end
 

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -85,7 +85,7 @@ module System
 
   # Returns the hardware model name.
   #
-  def self.model #: String
+  def self.model : String
     mib = Int32[LibC::CTL_HW, LibC::HW_MODEL]
     buf = Bytes.new(256)
     size = ::LibC::SizeT.new(256)

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -46,7 +46,7 @@ module System
     uname_struct = LibC::Uname.new
 
     if LibC.uname(pointerof(uname_struct)) < 0
-      raise "uname function call failed"
+      raise RuntimeError.from_errno("uname")
     else
       Uname.new(uname_struct)
     end

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -89,7 +89,7 @@ module System
     {% if flag?(:darwin) %}
       mib = Int32[LibC::CTL_HW, LibC::HW_MODEL]
       buf = Bytes.new(256)
-      size = ::LibC::SizeT.new(256)
+      size = ::LibC::SizeT.new(buf.size)
 
       if LibC.sysctl(mib, 2, buf, pointerof(size), nil, 0) < 0
         raise RuntimeError.from_errno("sysctl")

--- a/src/unix/uname.cr
+++ b/src/unix/uname.cr
@@ -85,15 +85,15 @@ module System
 
   # Returns the hardware model name.
   #
-  def self.model : String
+  def self.model #: String
     mib = Int32[LibC::CTL_HW, LibC::HW_MODEL]
-    buf = GC.malloc_atomic(256).as(UInt8*)
+    buf = Bytes.new(256)
     size = ::LibC::SizeT.new(256)
 
     if LibC.sysctl(mib, 2, buf, pointerof(size), nil, 0) < 0
       raise "sysctl function failed"
     end
 
-    String.new(buf, size - 1)
+    String.new(buf)[0, size - 1]
   end
 end


### PR DESCRIPTION
This adds the `model` method for Darwin, and fixes the code for Linux, which has a different buffer size, and an extra field called `domainname`. I also updated the specs, and made some other platform-specific updates.